### PR TITLE
Add ORI activity pedagogical sheets

### DIFF
--- a/ActivteORI/20T1-secteurs/fiche-pedagogique.md
+++ b/ActivteORI/20T1-secteurs/fiche-pedagogique.md
@@ -1,0 +1,29 @@
+# Activité 20T1 secteurs
+
+## Objectifs pédagogiques
+- Explorer les secteurs de formation professionnelle offerts dans la région.
+- Relier les secteurs d'intérêt aux talents et aux aspirations des élèves.
+- Développer la capacité à utiliser des outils numériques de recherche d'information.
+
+## Compétences visées
+- Compétence 1 : Se connaître et explorer le monde du travail.
+- Compétence 2 : S'orienter en utilisant des ressources numériques fiables.
+
+## Durée
+- 2 périodes de 60 minutes.
+
+## Matériel requis
+- Appareil numérique (ordinateur ou tablette) avec accès à Internet.
+- Fiches de prise de notes pour chaque secteur.
+- Tableau ou support collaboratif en ligne (ex. : Jamboard, Padlet).
+
+## Déroulement proposé
+1. **Mise en situation (10 min)** : Présenter les secteurs de formation disponibles sur la plateforme et rappeler les liens avec le projet personnel de l'élève.
+2. **Exploration guidée (40 min)** : En équipes, les élèves consultent les ressources en ligne et remplissent leur fiche sectorielle.
+3. **Mise en commun (20 min)** : Chaque équipe partage un secteur découvert et souligne trois faits marquants.
+4. **Retour réflexif (10 min)** : Les élèves identifient les secteurs qui les interpellent et justifient leur choix dans leur journal de bord.
+
+## Évaluation
+- Observation des échanges durant l'exploration.
+- Qualité des fiches remplies.
+- Autoévaluation des apprentissages.

--- a/ActivteORI/Mon-avatar/fiche-pedagogique.md
+++ b/ActivteORI/Mon-avatar/fiche-pedagogique.md
@@ -1,0 +1,28 @@
+# Activité Mon avatar
+
+## Objectifs pédagogiques
+- Amener l'élève à dresser un portrait de ses forces, intérêts et valeurs.
+- Favoriser l'expression de soi par un médium créatif.
+- Relier les traits personnels aux exigences des métiers explorés.
+
+## Compétences visées
+- Compétence 1 : Se connaître pour faire des choix éclairés.
+- Compétence 3 : Communiquer sa démarche d'orientation.
+
+## Durée
+- 1 période de 75 minutes.
+
+## Matériel requis
+- Ordinateurs ou tablettes avec l'application de création d'avatar.
+- Fiche réflexive imprimée ou numérique.
+- Casques d'écoute (optionnel).
+
+## Déroulement proposé
+1. **Introduction (10 min)** : Discussion sur l'importance de se connaître avant d'explorer les métiers.
+2. **Création de l'avatar (30 min)** : Les élèves conçoivent un avatar qui illustre leurs forces et leurs intérêts.
+3. **Analyse guidée (20 min)** : À partir d'une grille fournie, ils associent chaque élément choisi à un atout personnel.
+4. **Partage (15 min)** : Présentation de l'avatar à un pair et rétroaction constructive.
+
+## Évaluation
+- Grille d'autoévaluation sur la connaissance de soi.
+- Qualité des liens établis entre l'avatar et les forces personnelles.

--- a/ActivteORI/Mythes-et-realites/fiche-pedagogique.md
+++ b/ActivteORI/Mythes-et-realites/fiche-pedagogique.md
@@ -1,0 +1,29 @@
+# Activité Mythes et réalités
+
+## Objectifs pédagogiques
+- Démystifier des croyances entourant la formation professionnelle et les métiers.
+- Développer l'esprit critique face aux sources d'information.
+- Encourager les échanges et l'écoute active au sein du groupe.
+
+## Compétences visées
+- Compétence 2 : Explorer le monde scolaire et professionnel.
+- Compétence 3 : Construire son plan d'action professionnel.
+
+## Durée
+- 2 périodes de 50 minutes.
+
+## Matériel requis
+- Cartes « mythe ou réalité » imprimées ou numériques.
+- Accès à des ressources de validation (sites Web, fiches métiers, témoignages vidéo).
+- Tableau blanc ou outil numérique collaboratif.
+
+## Déroulement proposé
+1. **Activation des connaissances (10 min)** : Brainstorming sur les idées préconçues à propos de la formation professionnelle.
+2. **Atelier en équipes (40 min)** : Chaque équipe pige des cartes et détermine si l'énoncé est un mythe ou une réalité en justifiant sa réponse avec des sources.
+3. **Plénière (30 min)** : Mise en commun et rectification des mythes les plus persistants.
+4. **Synthèse individuelle (20 min)** : Les élèves rédigent trois apprentissages clés et une question qu'ils souhaitent approfondir.
+
+## Évaluation
+- Qualité des justifications présentées.
+- Participation active aux discussions.
+- Pertinence de la synthèse individuelle.

--- a/ActivteORI/README.md
+++ b/ActivteORI/README.md
@@ -1,0 +1,16 @@
+# Les Secteurs
+
+Ce dépôt contient une interface Web et diverses ressources pour explorer les secteurs de formation professionnelle. Les images et documents sont organisés par dossiers thématiques (infos métiers, ressources, secteurs, etc.).
+
+## Nouveau : ActivteORI
+
+Le dossier `ActivteORI` regroupe les fiches pédagogiques associées aux activités proposées dans la section « Activités » de la plateforme.
+
+### Contenu des fiches
+- `20T1-secteurs/fiche-pedagogique.md`
+- `Mon-avatar/fiche-pedagogique.md`
+- `Mythes-et-realites/fiche-pedagogique.md`
+- `RIASEC/fiche-pedagogique.md`
+- `Systeme-scolaire/fiche-pedagogique.md`
+
+Chaque fiche précise les objectifs, compétences visées, durée, matériel requis, déroulement détaillé et modalités d'évaluation. Elles peuvent être adaptées selon le contexte de classe ou d'orientation.

--- a/ActivteORI/RIASEC/fiche-pedagogique.md
+++ b/ActivteORI/RIASEC/fiche-pedagogique.md
@@ -1,0 +1,29 @@
+# Activité RIASEC
+
+## Objectifs pédagogiques
+- Comprendre les six dimensions du modèle RIASEC.
+- Identifier son profil dominant à partir d'un questionnaire ou d'activités pratiques.
+- Relier son profil aux secteurs et métiers présentés sur la plateforme.
+
+## Compétences visées
+- Compétence 1 : Se connaître en explorant ses intérêts.
+- Compétence 2 : Mettre en relation ses intérêts avec des environnements de travail.
+
+## Durée
+- 1 période de 60 minutes.
+
+## Matériel requis
+- Questionnaire RIASEC (imprimé ou en ligne).
+- Profil des secteurs et métiers liés à chaque type RIASEC.
+- Crayons, surligneurs, feuilles de synthèse.
+
+## Déroulement proposé
+1. **Présentation (15 min)** : Explication du modèle RIASEC et exemples de métiers associés.
+2. **Questionnaire (20 min)** : Les élèves répondent au questionnaire et compilent leurs résultats.
+3. **Analyse (15 min)** : Mise en relation des lettres obtenues avec les secteurs de la plateforme.
+4. **Plan d'action (10 min)** : Chaque élève identifie deux pistes d'exploration à poursuivre.
+
+## Évaluation
+- Complétion du questionnaire.
+- Pertinence des liens faits entre le profil et les métiers ciblés.
+- Engagement dans l'élaboration du plan d'action.

--- a/ActivteORI/Systeme-scolaire/fiche-pedagogique.md
+++ b/ActivteORI/Systeme-scolaire/fiche-pedagogique.md
@@ -1,0 +1,29 @@
+# Activité Système scolaire
+
+## Objectifs pédagogiques
+- Comprendre les différentes voies de formation au Québec après le secondaire.
+- Distinguer les parcours liés aux métiers présentés sur la plateforme.
+- Élaborer un plan personnel de cheminement scolaire.
+
+## Compétences visées
+- Compétence 2 : Explorer le système scolaire et professionnel.
+- Compétence 3 : Planifier ses prochaines étapes de formation.
+
+## Durée
+- 2 périodes de 60 minutes.
+
+## Matériel requis
+- Schémas du système scolaire québécois.
+- Fiches descriptives des programmes (DEP, ASP, DEC, etc.).
+- Tableau interactif ou projecteur.
+
+## Déroulement proposé
+1. **Présentation (20 min)** : Animation interactive pour présenter les différentes voies de formation.
+2. **Étude de cas (40 min)** : En équipes, les élèves reçoivent des profils fictifs et doivent proposer un cheminement adapté.
+3. **Recherche individuelle (30 min)** : Chaque élève identifie le parcours qui correspond à ses objectifs et complète une fiche de planification.
+4. **Retour collectif (30 min)** : Discussion sur les obstacles possibles et les ressources disponibles.
+
+## Évaluation
+- Analyse des études de cas.
+- Pertinence du plan personnel rédigé.
+- Participation aux échanges collectifs.


### PR DESCRIPTION
## Summary
- add the new `ActivteORI` directory to host ORI activity resources
- create pedagogical sheets for each activity covering objectives, duration, material, steps, and evaluation
- document the new folder structure and contents in a README for quick reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66bdf0fec832eaec655ab425c447e