### PR TITLE
Add offline fallback for activity PDF downloads

### DIFF
--- a/ExploIFP3.html
+++ b/ExploIFP3.html
@@ -1036,6 +1036,166 @@
 
     <div id="pdf-export-container" class="pdf-export-container"></div>
 
+    <!-- Contenu Markdown intégré pour le téléchargement hors ligne -->
+    <script type="text/plain" id="markdown-mon-avatar">
+# Activité Mon avatar
+
+## Objectifs pédagogiques
+- Amener l'élève à dresser un portrait de ses forces, intérêts et valeurs.
+- Favoriser l'expression de soi par un médium créatif.
+- Relier les traits personnels aux exigences des métiers explorés.
+
+## Compétences visées
+- Compétence 1 : Se connaître pour faire des choix éclairés.
+- Compétence 3 : Communiquer sa démarche d'orientation.
+
+## Durée
+- 1 période de 75 minutes.
+
+## Matériel requis
+- Ordinateurs ou tablettes avec l'application de création d'avatar.
+- Fiche réflexive imprimée ou numérique.
+- Casques d'écoute (optionnel).
+
+## Déroulement proposé
+1. **Introduction (10 min)** : Discussion sur l'importance de se connaître avant d'explorer les métiers.
+2. **Création de l'avatar (30 min)** : Les élèves conçoivent un avatar qui illustre leurs forces et leurs intérêts.
+3. **Analyse guidée (20 min)** : À partir d'une grille fournie, ils associent chaque élément choisi à un atout personnel.
+4. **Partage (15 min)** : Présentation de l'avatar à un pair et rétroaction constructive.
+
+## Évaluation
+- Grille d'autoévaluation sur la connaissance de soi.
+- Qualité des liens établis entre l'avatar et les forces personnelles.
+    </script>
+
+    <script type="text/plain" id="markdown-20t1-secteurs">
+# Activité 20T1 secteurs
+
+## Objectifs pédagogiques
+- Explorer les secteurs de formation professionnelle offerts dans la région.
+- Relier les secteurs d'intérêt aux talents et aux aspirations des élèves.
+- Développer la capacité à utiliser des outils numériques de recherche d'information.
+
+## Compétences visées
+- Compétence 1 : Se connaître et explorer le monde du travail.
+- Compétence 2 : S'orienter en utilisant des ressources numériques fiables.
+
+## Durée
+- 2 périodes de 60 minutes.
+
+## Matériel requis
+- Appareil numérique (ordinateur ou tablette) avec accès à Internet.
+- Fiches de prise de notes pour chaque secteur.
+- Tableau ou support collaboratif en ligne (ex. : Jamboard, Padlet).
+
+## Déroulement proposé
+1. **Mise en situation (10 min)** : Présenter les secteurs de formation disponibles sur la plateforme et rappeler les liens avec le projet personnel de l'élève.
+2. **Exploration guidée (40 min)** : En équipes, les élèves consultent les ressources en ligne et remplissent leur fiche sectorielle.
+3. **Mise en commun (20 min)** : Chaque équipe partage un secteur découvert et souligne trois faits marquants.
+4. **Retour réflexif (10 min)** : Les élèves identifient les secteurs qui les interpellent et justifient leur choix dans leur journal de bord.
+
+## Évaluation
+- Observation des échanges durant l'exploration.
+- Qualité des fiches remplies.
+- Autoévaluation des apprentissages.
+    </script>
+
+    <script type="text/plain" id="markdown-mythes-et-realites">
+# Activité Mythes et réalités
+
+## Objectifs pédagogiques
+- Démystifier des croyances entourant la formation professionnelle et les métiers.
+- Développer l'esprit critique face aux sources d'information.
+- Encourager les échanges et l'écoute active au sein du groupe.
+
+## Compétences visées
+- Compétence 2 : Explorer le monde scolaire et professionnel.
+- Compétence 3 : Construire son plan d'action professionnel.
+
+## Durée
+- 2 périodes de 50 minutes.
+
+## Matériel requis
+- Cartes « mythe ou réalité » imprimées ou numériques.
+- Accès à des ressources de validation (sites Web, fiches métiers, témoignages vidéo).
+- Tableau blanc ou outil numérique collaboratif.
+
+## Déroulement proposé
+1. **Activation des connaissances (10 min)** : Brainstorming sur les idées préconçues à propos de la formation professionnelle.
+2. **Atelier en équipes (40 min)** : Chaque équipe pige des cartes et détermine si l'énoncé est un mythe ou une réalité en justifiant sa réponse avec des sources.
+3. **Plénière (30 min)** : Mise en commun et rectification des mythes les plus persistants.
+4. **Synthèse individuelle (20 min)** : Les élèves rédigent trois apprentissages clés et une question qu'ils souhaitent approfondir.
+
+## Évaluation
+- Qualité des justifications présentées.
+- Participation active aux discussions.
+- Pertinence de la synthèse individuelle.
+    </script>
+
+    <script type="text/plain" id="markdown-riasec">
+# Activité RIASEC
+
+## Objectifs pédagogiques
+- Comprendre les six dimensions du modèle RIASEC.
+- Identifier son profil dominant à partir d'un questionnaire ou d'activités pratiques.
+- Relier son profil aux secteurs et métiers présentés sur la plateforme.
+
+## Compétences visées
+- Compétence 1 : Se connaître en explorant ses intérêts.
+- Compétence 2 : Mettre en relation ses intérêts avec des environnements de travail.
+
+## Durée
+- 1 période de 60 minutes.
+
+## Matériel requis
+- Questionnaire RIASEC (imprimé ou en ligne).
+- Profil des secteurs et métiers liés à chaque type RIASEC.
+- Crayons, surligneurs, feuilles de synthèse.
+
+## Déroulement proposé
+1. **Présentation (15 min)** : Explication du modèle RIASEC et exemples de métiers associés.
+2. **Questionnaire (20 min)** : Les élèves répondent au questionnaire et compilent leurs résultats.
+3. **Analyse (15 min)** : Mise en relation des lettres obtenues avec les secteurs de la plateforme.
+4. **Plan d'action (10 min)** : Chaque élève identifie deux pistes d'exploration à poursuivre.
+
+## Évaluation
+- Complétion du questionnaire.
+- Pertinence des liens faits entre le profil et les métiers ciblés.
+- Engagement dans l'élaboration du plan d'action.
+    </script>
+
+    <script type="text/plain" id="markdown-systeme-scolaire">
+# Activité Système scolaire
+
+## Objectifs pédagogiques
+- Comprendre les différentes voies de formation au Québec après le secondaire.
+- Distinguer les parcours liés aux métiers présentés sur la plateforme.
+- Élaborer un plan personnel de cheminement scolaire.
+
+## Compétences visées
+- Compétence 2 : Explorer le système scolaire et professionnel.
+- Compétence 3 : Planifier ses prochaines étapes de formation.
+
+## Durée
+- 2 périodes de 60 minutes.
+
+## Matériel requis
+- Schémas du système scolaire québécois.
+- Fiches descriptives des programmes (DEP, ASP, DEC, etc.).
+- Tableau interactif ou projecteur.
+
+## Déroulement proposé
+1. **Présentation (20 min)** : Animation interactive pour présenter les différentes voies de formation.
+2. **Étude de cas (40 min)** : En équipes, les élèves reçoivent des profils fictifs et doivent proposer un cheminement adapté.
+3. **Recherche individuelle (30 min)** : Chaque élève identifie le parcours qui correspond à ses objectifs et complète une fiche de planification.
+4. **Retour collectif (30 min)** : Discussion sur les obstacles possibles et les ressources disponibles.
+
+## Évaluation
+- Analyse des études de cas.
+- Pertinence du plan personnel rédigé.
+- Participation aux échanges collectifs.
+    </script>
+
     <script>
         // Configuration globale
         let allMetiersData = {};
@@ -1054,29 +1214,43 @@
             "mon-avatar": {
                 markdownPath: "ActivteORI/Mon-avatar/fiche-pedagogique.md",
                 filename: "Activite_Mon_avatar.pdf",
-                title: "Activité Mon avatar"
+                title: "Activité Mon avatar",
+                inlineMarkdownId: "markdown-mon-avatar"
             },
             "20t1-secteurs": {
                 markdownPath: "ActivteORI/20T1-secteurs/fiche-pedagogique.md",
                 filename: "Activite_20T1_secteurs.pdf",
-                title: "Activité 20T1 secteurs"
+                title: "Activité 20T1 secteurs",
+                inlineMarkdownId: "markdown-20t1-secteurs"
             },
             "mythes-et-realites": {
                 markdownPath: "ActivteORI/Mythes-et-realites/fiche-pedagogique.md",
                 filename: "Activite_Mythes_et_realites.pdf",
-                title: "Activité Mythes et réalités"
+                title: "Activité Mythes et réalités",
+                inlineMarkdownId: "markdown-mythes-et-realites"
             },
             "riasec": {
                 markdownPath: "ActivteORI/RIASEC/fiche-pedagogique.md",
                 filename: "Activite_RIASEC.pdf",
-                title: "Activité RIASEC"
+                title: "Activité RIASEC",
+                inlineMarkdownId: "markdown-riasec"
             },
             "systeme-scolaire": {
                 markdownPath: "ActivteORI/Systeme-scolaire/fiche-pedagogique.md",
                 filename: "Activite_Systeme_scolaire.pdf",
-                title: "Activité Système scolaire"
+                title: "Activité Système scolaire",
+                inlineMarkdownId: "markdown-systeme-scolaire"
             }
         };
+
+        function getInlineMarkdown(config) {
+            if (!config.inlineMarkdownId) {
+                return "";
+            }
+
+            const element = document.getElementById(config.inlineMarkdownId);
+            return element ? element.textContent.trim() : "";
+        }
 
         async function downloadActivityPdf(activityKey) {
             const config = activityPdfConfig[activityKey];
@@ -1092,12 +1266,32 @@
             }
 
             try {
-                const response = await fetch(config.markdownPath);
-                if (!response.ok) {
-                    throw new Error(`Fichier introuvable (code ${response.status})`);
+                let markdown = "";
+                const inlineMarkdown = getInlineMarkdown(config);
+                const isFileProtocol = window.location.protocol === 'file:';
+
+                if (!isFileProtocol) {
+                    try {
+                        const response = await fetch(config.markdownPath);
+                        if (!response.ok) {
+                            throw new Error(`Fichier introuvable (code ${response.status})`);
+                        }
+
+                        markdown = await response.text();
+                    } catch (networkError) {
+                        if (inlineMarkdown) {
+                            console.warn('Échec du chargement du Markdown via fetch, utilisation du contenu intégré.', networkError);
+                            markdown = inlineMarkdown;
+                        } else {
+                            throw networkError;
+                        }
+                    }
+                } else if (inlineMarkdown) {
+                    markdown = inlineMarkdown;
+                } else {
+                    throw new Error("Contenu Markdown indisponible hors ligne.");
                 }
 
-                const markdown = await response.text();
                 const cleanedMarkdown = markdown.replace(/^#\s.*\n+/, '');
                 const htmlContent = marked.parse(cleanedMarkdown);
 


### PR DESCRIPTION
## Summary
- embed the activity markdown content in the page as an offline fallback
- update the PDF generation logic to use the inline content when fetch fails or when opened via file://

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e682aa1170832e8c56c119b0af98da